### PR TITLE
ci: add baseline pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: pip
+          cache-dependency-path: Pipfile.lock
+
+      - name: Install validation tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pipenv PyYAML
+
+      - name: Verify Pipfile.lock
+        run: pipenv verify
+
+      - name: Check Python syntax
+        run: python -m compileall -q site
+
+      - name: Validate YAML syntax
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          import yaml
+
+
+          for path in Path(".").rglob("*"):
+              if not path.is_file():
+                  continue
+              if path.suffix not in {".yml", ".yaml"}:
+                  continue
+              if ".git" in path.parts:
+                  continue
+
+              with path.open("r", encoding="utf-8") as stream:
+                  list(yaml.safe_load_all(stream))
+
+              print(f"Valid YAML: {path}")
+          PY
+
+  docker-build:
+    name: Docker build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image without publishing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          build-args: |
+            OEDATAREP_RELEASE=${{ vars.OEDATAREP_RELEASE }}
+          tags: oedatarep-invenio-rdm:ci

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,40 +1,42 @@
-name: Docker Image CI
+name: Docker Image Release
 
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
+
+permissions:
+  contents: read
 
 jobs:
-  build:
+  build-and-push:
+    name: Build and publish image
     runs-on: ubuntu-latest
 
     steps:
-    # Checkout source code
-    - uses: actions/checkout@v4
-      with:
-          ref: 'main'
+      - name: Check out tagged source
+        uses: actions/checkout@v4
 
-    # Login to Docker Hub
-    - name: Docker Login
-      uses: docker/login-action@v3.3.0
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Determine image tag
-      id: tag
-      run: |
-        echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Determine image tag
+        id: image-tag
+        shell: bash
+        run: echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
-    # Push image to registry
-    - name: Build and push Docker images
-      uses: docker/build-push-action@v6.9.0
-      with:
-        push: true
-        build-args: |
-          OEDATAREP_RELEASE=${{ vars.OEDATAREP_RELEASE }}
-        tags: oedatarep/oedatarep-invenio-rdm:${{ steps.tag.outputs.tag }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            OEDATAREP_RELEASE=${{ vars.OEDATAREP_RELEASE }}
+          tags: |
+            oedatarep/oedatarep-invenio-rdm:${{ steps.image-tag.outputs.tag }}


### PR DESCRIPTION
## Summary

This pull request introduces a baseline GitHub Actions configuration for OEDataRep.

### Changes

- add pull request and `main` branch validation workflow;
- validate `Pipfile.lock`;
- check Python syntax;
- validate YAML syntax;
- build the Docker image without publishing it;
- build release images from the commit referenced by the release tag;
- apply read-only permissions to the workflows.

## Motivation

The repository currently has no automated validation for pull requests, and the release workflow explicitly checks out `main` instead of the commit referenced by the tag.

This pull request establishes the first CI baseline before enabling branch protection and required status checks on `main`.

## Validation plan

The new checks are initially introduced without making them required:

- `CI / Validate`
- `CI / Docker build`

The results of this pull request will be used to verify the reliability and naming of the checks before configuring the `main` branch ruleset.

## Notes

- no tests or strict linting are introduced in this iteration;
- the repository variable `OEDATAREP_RELEASE` remains unchanged;
- the workflow continues to use the existing Docker Hub secrets only for tagged releases.
