### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report vulnerabilities, exposed credentials, personal data, or
+other sensitive security issues through public GitHub issues.
+
+Use GitHub's private vulnerability reporting feature to report suspected
+vulnerabilities affecting the OEDataRep source code.
+
+When available, include:
+
+- a description of the vulnerability;
+- steps to reproduce it;
+- the affected component or version;
+- the potential impact;
+- relevant logs or screenshots with sensitive information minimized.
+
+The OEDataRep maintainers will review the report and coordinate the appropriate
+remediation and disclosure process.


### PR DESCRIPTION
## Summary

Add a security policy that directs users to GitHub Private Vulnerability
Reporting for suspected vulnerabilities and sensitive security issues.

## Motivation

Provide a private and documented reporting channel without exposing sensitive
information through public issues.

## Validation

- Verified that Private Vulnerability Reporting is enabled.
- Reviewed the rendered Markdown.